### PR TITLE
update jersey dependency to version 2.24.

### DIFF
--- a/raml-client-generator-core/pom.xml
+++ b/raml-client-generator-core/pom.xml
@@ -16,7 +16,7 @@
     </parent>
 
     <properties>
-        <jersey.version>2.17</jersey.version>
+        <jersey.version>2.24</jersey.version>
     </properties>
 
     <dependencies>

--- a/raml-client-generator-example/pom.xml
+++ b/raml-client-generator-example/pom.xml
@@ -15,23 +15,27 @@
         <version>0.2-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <jersey.version>2.24</jersey.version>
+    </properties>
+
     <dependencies>
         <!--Jersey client-->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.17</version>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.17</version>
+            <version>${jersey.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>2.17</version>
+            <version>${jersey.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
use the same jersey version as raml-for-jax-rs (jaxrs-parser)

additional fixes an upstream bug (due to stale Maven repo) of jersey. see: https://github.com/jersey/jersey/commit/ec0c70a6ef057b37ee7809b0ed23295e36747d78#diff-600376dffeb79835ede4a0b285078036L1138

for many other improvements see changelog of jersey: https://github.com/jersey/jersey/releases

