### PR TITLE
Changed the visibility of the generated getClient method to protected.

### DIFF
--- a/raml-client-generator-core/src/main/java/org/mule/client/codegen/RamlJavaClientGenerator.java
+++ b/raml-client-generator-core/src/main/java/org/mule/client/codegen/RamlJavaClientGenerator.java
@@ -217,7 +217,7 @@ public class RamlJavaClientGenerator {
                             resourceClass.javadoc().add(resourceDescription);
                         }
 
-                        final JMethod getClient = resourceClass.method(JMod.PRIVATE, Client.class, "getClient");
+                        final JMethod getClient = resourceClass.method(JMod.PROTECTED, Client.class, "getClient");
                         getClient.body()._return(JExpr._this().ref("client"));
 
                         final JFieldVar baseUrlField = resourceClass.field(JMod.PRIVATE, String.class, PRIVATE_FIELD_PREFIX + BASE_URL_FIELD_NAME);

--- a/raml-client-generator-core/src/main/java/org/mule/client/codegen/clientgenerator/Jersey2RestClientGeneratorImpl.java
+++ b/raml-client-generator-core/src/main/java/org/mule/client/codegen/clientgenerator/Jersey2RestClientGeneratorImpl.java
@@ -153,7 +153,7 @@ public class Jersey2RestClientGeneratorImpl implements RestClientGenerator {
 
     @Override
     public JMethod createClient(JCodeModel cm, JDefinedClass resourceClass, JMethod baseUrlMethod) {
-        final JMethod clientMethod = resourceClass.method(JMod.PRIVATE, WebTarget.class, "getClient");
+        final JMethod clientMethod = resourceClass.method(JMod.PROTECTED, WebTarget.class, "getClient");
         final JBlock methodBody = clientMethod.body();
         final JVar client = methodBody.decl(JMod.FINAL, cm.ref(Client.class), "client", cm.directClass(ClientBuilder.class.getName()).staticInvoke("newClient"));
         final JVar target = methodBody.decl(JMod.FINAL, cm.ref(WebTarget.class), "target", client.invoke("target").arg(JExpr.invoke(baseUrlMethod)));

--- a/raml-client-generator-core/src/main/java/org/mule/client/codegen/security/BasicAuthClientGenerator.java
+++ b/raml-client-generator-core/src/main/java/org/mule/client/codegen/security/BasicAuthClientGenerator.java
@@ -19,7 +19,7 @@ public class BasicAuthClientGenerator implements SecurityClientGenerator {
     @Override
     public JMethod createClient(JDefinedClass containerClass) {
         JCodeModel cm = new JCodeModel();
-        JMethod getClient = containerClass.method(JMod.PRIVATE, Client.class, "getClient");
+        JMethod getClient = containerClass.method(JMod.PROTECTED, Client.class, "getClient");
         JBlock body = getClient.body();
 
         JVar decl = body.decl(JMod.FINAL, cm._ref(Client.class), "client", cm.anonymousClass(ClientBuilder.class).staticInvoke("newClient"));

--- a/raml-client-generator-core/src/main/java/org/mule/client/codegen/security/NoSecuredClientGenerator.java
+++ b/raml-client-generator-core/src/main/java/org/mule/client/codegen/security/NoSecuredClientGenerator.java
@@ -13,7 +13,7 @@ public class NoSecuredClientGenerator implements SecurityClientGenerator {
     @Override
     public JMethod createClient(JDefinedClass containerClass) {
         JCodeModel cm = new JCodeModel();
-        JMethod getClient = containerClass.method(JMod.PRIVATE, Client.class, "getClient");
+        JMethod getClient = containerClass.method(JMod.PROTECTED, Client.class, "getClient");
         getClient.body()._return(cm.anonymousClass(ClientBuilder.class).staticInvoke("newClient"));
         return getClient;
     }

--- a/raml-client-generator-core/src/test/resources/form-parameters/output/form-parameters/api/DataWeaveAPIClient.java
+++ b/raml-client-generator-core/src/test/resources/form-parameters/output/form-parameters/api/DataWeaveAPIClient.java
@@ -24,7 +24,7 @@ public class DataWeaveAPIClient {
         this("http://dataweave-api.cloudhub.io/api");
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return ClientBuilder.newClient();
     }
 

--- a/raml-client-generator-core/src/test/resources/form-parameters/output/form-parameters/resource/exec/Exec.java
+++ b/raml-client-generator-core/src/test/resources/form-parameters/output/form-parameters/resource/exec/Exec.java
@@ -22,7 +22,7 @@ public class Exec {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/global-type-body/output/global-type-body/api/FooClient.java
+++ b/raml-client-generator-core/src/test/resources/global-type-body/output/global-type-body/api/FooClient.java
@@ -20,7 +20,7 @@ public class FooClient {
         cs = new Cs(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return ClientBuilder.newClient();
     }
 

--- a/raml-client-generator-core/src/test/resources/global-type-body/output/global-type-body/resource/cs/Cs.java
+++ b/raml-client-generator-core/src/test/resources/global-type-body/output/global-type-body/resource/cs/Cs.java
@@ -16,7 +16,7 @@ public class Cs {
         login = new Login(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/global-type-body/output/global-type-body/resource/cs/login/Login.java
+++ b/raml-client-generator-core/src/test/resources/global-type-body/output/global-type-body/resource/cs/login/Login.java
@@ -20,7 +20,7 @@ public class Login {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/global-type-return/output/global-type-return/api/FooClient.java
+++ b/raml-client-generator-core/src/test/resources/global-type-return/output/global-type-return/api/FooClient.java
@@ -20,7 +20,7 @@ public class FooClient {
         cs = new Cs(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return ClientBuilder.newClient();
     }
 

--- a/raml-client-generator-core/src/test/resources/global-type-return/output/global-type-return/resource/cs/Cs.java
+++ b/raml-client-generator-core/src/test/resources/global-type-return/output/global-type-return/resource/cs/Cs.java
@@ -16,7 +16,7 @@ public class Cs {
         login = new Login(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/global-type-return/output/global-type-return/resource/cs/login/Login.java
+++ b/raml-client-generator-core/src/test/resources/global-type-return/output/global-type-return/resource/cs/login/Login.java
@@ -18,7 +18,7 @@ public class Login {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/list/output/list/api/FooClient.java
+++ b/raml-client-generator-core/src/test/resources/list/output/list/api/FooClient.java
@@ -20,7 +20,7 @@ public class FooClient {
         users = new Users(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return ClientBuilder.newClient();
     }
 

--- a/raml-client-generator-core/src/test/resources/list/output/list/resource/users/Users.java
+++ b/raml-client-generator-core/src/test/resources/list/output/list/resource/users/Users.java
@@ -21,7 +21,7 @@ public class Users {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/multi_body/output/multi_body/api/MultiBodyClient.java
+++ b/raml-client-generator-core/src/test/resources/multi_body/output/multi_body/api/MultiBodyClient.java
@@ -20,7 +20,7 @@ public class MultiBodyClient {
         cs = new Cs(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return ClientBuilder.newClient();
     }
 

--- a/raml-client-generator-core/src/test/resources/multi_body/output/multi_body/resource/cs/Cs.java
+++ b/raml-client-generator-core/src/test/resources/multi_body/output/multi_body/resource/cs/Cs.java
@@ -16,7 +16,7 @@ public class Cs {
         login = new Login(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/multi_body/output/multi_body/resource/cs/login/Login.java
+++ b/raml-client-generator-core/src/test/resources/multi_body/output/multi_body/resource/cs/login/Login.java
@@ -18,7 +18,7 @@ public class Login {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/simple/output/simple/api/FooClient.java
+++ b/raml-client-generator-core/src/test/resources/simple/output/simple/api/FooClient.java
@@ -20,7 +20,7 @@ public class FooClient {
         cs = new Cs(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return ClientBuilder.newClient();
     }
 

--- a/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/Cs.java
+++ b/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/Cs.java
@@ -20,7 +20,7 @@ public class Cs {
         login = new Login(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/data/Data.java
+++ b/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/data/Data.java
@@ -16,7 +16,7 @@ public class Data {
         foo = new Foo(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/data/foo/Foo.java
+++ b/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/data/foo/Foo.java
@@ -20,7 +20,7 @@ public class Foo {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/id/Id.java
+++ b/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/id/Id.java
@@ -21,7 +21,7 @@ public class Id {
         bar = new Bar(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/id/bar/Bar.java
+++ b/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/id/bar/Bar.java
@@ -18,7 +18,7 @@ public class Bar {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/login/Login.java
+++ b/raml-client-generator-core/src/test/resources/simple/output/simple/resource/cs/login/Login.java
@@ -18,7 +18,7 @@ public class Login {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-core/src/test/resources/x-www-form-urlencoded/output/x-www-form-urlencoded/api/TestsendformdataClient.java
+++ b/raml-client-generator-core/src/test/resources/x-www-form-urlencoded/output/x-www-form-urlencoded/api/TestsendformdataClient.java
@@ -20,7 +20,7 @@ public class TestsendformdataClient {
         sendFormData = new SendFormData(getBaseUri(), getClient());
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return ClientBuilder.newClient();
     }
 

--- a/raml-client-generator-core/src/test/resources/x-www-form-urlencoded/output/x-www-form-urlencoded/resource/sendFormData/SendFormData.java
+++ b/raml-client-generator-core/src/test/resources/x-www-form-urlencoded/output/x-www-form-urlencoded/resource/sendFormData/SendFormData.java
@@ -21,7 +21,7 @@ public class SendFormData {
         this.client = client;
     }
 
-    private Client getClient() {
+    protected Client getClient() {
         return this.client;
     }
 

--- a/raml-client-generator-example/src/test/java/ClientExampleWithCustomClient.java
+++ b/raml-client-generator-example/src/test/java/ClientExampleWithCustomClient.java
@@ -1,0 +1,23 @@
+import org.glassfish.jersey.client.ClientProperties;
+import org.mule.example.api.ClientAPIClient;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+
+public class ClientExampleWithCustomClient {
+    public static void main(final String[] args) {
+
+        final ClientAPIClient client = new ClientAPIClient() {
+            @Override
+            protected Client getClient() {
+                final Client client = ClientBuilder.newClient();
+                client.property(ClientProperties.CONNECT_TIMEOUT, 1000);
+                client.property(ClientProperties.READ_TIMEOUT, 1000);
+                return client;
+            }
+        };
+        client.users.userId("luis").get();
+
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,21 @@ Using the generated api
 final List<UsersGETResponse> result = ClientAPIClient.create().users.get();
 ```
 
+Customizing the client 
+
+```java
+final ClientAPIClient client = new ClientAPIClient() {
+    @Override
+    protected Client getClient() {
+        final Client client = ClientBuilder.newClient();
+        client.property(ClientProperties.CONNECT_TIMEOUT, 1000);
+        client.property(ClientProperties.READ_TIMEOUT, 1000);
+        return client;
+    }
+};
+client.users.userId("luis").get();
+```
+
 ## Using it from java
 
 It can easily be embedded into your code just add de dependency


### PR DESCRIPTION
This has the benefit of being able to customize the Jersey client. For example this makes it possible to specify timeouts. (see issue #8)

Additionally:
- Added a small example
- updated readme.md