### PR TITLE
ignore eclipse classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 .idea
 *.iml
+.project
+.classpath
+.settings


### PR DESCRIPTION
To avoid outgoing changes when working in eclipse, please extend .gitignore