### PR TITLE
 Fixed issue when multiple subresources are defined with full path.

### DIFF
--- a/raml-client-generator-core/src/main/java/org/mule/client/codegen/RamlJavaClientGenerator.java
+++ b/raml-client-generator-core/src/main/java/org/mule/client/codegen/RamlJavaClientGenerator.java
@@ -328,6 +328,7 @@ public class RamlJavaClientGenerator {
                         final Pair<JDefinedClass, JMethod> resourcePair = this.resourceClasses.get(resourcePath);
                         resourceClass = resourcePair.getLeft();
                         resourceConstructor = resourcePair.getRight();
+                        defaultConstructor = resourceClass.getConstructor(new JType[] {});
                     }
 
                     parentClass = resourceClass;

--- a/raml-client-generator-core/src/test/java/org/mule/client/codegen/RamlJavaClientGeneratorTest.java
+++ b/raml-client-generator-core/src/test/java/org/mule/client/codegen/RamlJavaClientGeneratorTest.java
@@ -46,6 +46,7 @@ public class RamlJavaClientGeneratorTest {
                 {"oauth20-global"},
                 {"simple"},
                 {"sub_resource_on_same_line"},
+                {"same_path_multiple_times"},
                 {"type_decl"},
                 {"x-www-form-urlencoded"}
         });

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/api.raml
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/api.raml
@@ -1,0 +1,32 @@
+#%RAML 1.0
+title: Foo
+version: 0.1
+mediaType: application/json
+documentation:
+  - title : Foo
+    content : A String
+/foo:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              { "message": "foo" }
+/foo/a:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              { "message": "foo" }
+/foo/b:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              { "message": "foo" }
+

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/api/FooClient.java
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/api/FooClient.java
@@ -1,0 +1,40 @@
+
+package same_path_multiple_times.api;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import same_path_multiple_times.resource.foo.Foo;
+
+
+/**
+ * A String
+ * 
+ */
+public class FooClient {
+
+    private String _baseUrl;
+    public final Foo foo;
+
+    public FooClient() {
+        _baseUrl = null;
+        foo = null;
+    }
+
+    public FooClient(String baseUrl) {
+        _baseUrl = baseUrl;
+        foo = new Foo(getBaseUri(), getClient());
+    }
+
+    protected Client getClient() {
+        return ClientBuilder.newClient();
+    }
+
+    protected String getBaseUri() {
+        return _baseUrl;
+    }
+
+    public static FooClient create(String baseUrl) {
+        return new FooClient(baseUrl);
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/exceptions/FooException.java
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/exceptions/FooException.java
@@ -1,0 +1,25 @@
+
+package same_path_multiple_times.exceptions;
+
+
+public class FooException
+    extends RuntimeException
+{
+
+    private int statusCode;
+    private String reason;
+
+    public FooException(int statusCode, String reason) {
+        this.statusCode = statusCode;
+        this.reason = reason;
+    }
+
+    public int getStatusCode() {
+        return this.statusCode;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/Foo.java
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/Foo.java
@@ -1,0 +1,53 @@
+
+package same_path_multiple_times.resource.foo;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import same_path_multiple_times.exceptions.FooException;
+import same_path_multiple_times.resource.foo.a.A;
+import same_path_multiple_times.resource.foo.b.B;
+
+public class Foo {
+
+    private String _baseUrl;
+    private Client _client;
+    public final A a;
+    public final B b;
+
+    public Foo() {
+        _baseUrl = null;
+        _client = null;
+        a = null;
+        b = null;
+    }
+
+    public Foo(String baseUrl, Client _client) {
+        _baseUrl = (baseUrl +"/foo");
+        this._client = _client;
+        a = new A(getBaseUri(), getClient());
+        b = new B(getBaseUri(), getClient());
+    }
+
+    protected Client getClient() {
+        return this._client;
+    }
+
+    private String getBaseUri() {
+        return _baseUrl;
+    }
+
+    public same_path_multiple_times.resource.foo.model.FooGETResponse get() {
+        WebTarget target = this._client.target(getBaseUri());
+        final javax.ws.rs.client.Invocation.Builder invocationBuilder = target.request(MediaType.APPLICATION_JSON_TYPE);
+        Response response = invocationBuilder.get();
+        if (response.getStatusInfo().getFamily()!= Family.SUCCESSFUL) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new FooException(statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
+        }
+        return response.readEntity(same_path_multiple_times.resource.foo.model.FooGETResponse.class);
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/a/A.java
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/a/A.java
@@ -1,0 +1,45 @@
+
+package same_path_multiple_times.resource.foo.a;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import same_path_multiple_times.exceptions.FooException;
+
+public class A {
+
+    private String _baseUrl;
+    private Client _client;
+
+    public A() {
+        _baseUrl = null;
+        _client = null;
+    }
+
+    public A(String baseUrl, Client _client) {
+        _baseUrl = (baseUrl +"/a");
+        this._client = _client;
+    }
+
+    protected Client getClient() {
+        return this._client;
+    }
+
+    private String getBaseUri() {
+        return _baseUrl;
+    }
+
+    public same_path_multiple_times.resource.foo.a.model.AGETResponse get() {
+        WebTarget target = this._client.target(getBaseUri());
+        final javax.ws.rs.client.Invocation.Builder invocationBuilder = target.request(MediaType.APPLICATION_JSON_TYPE);
+        Response response = invocationBuilder.get();
+        if (response.getStatusInfo().getFamily()!= Family.SUCCESSFUL) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new FooException(statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
+        }
+        return response.readEntity(same_path_multiple_times.resource.foo.a.model.AGETResponse.class);
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/a/model/AGETResponse.java
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/a/model/AGETResponse.java
@@ -1,0 +1,95 @@
+
+package same_path_multiple_times.resource.foo.a.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "message"
+})
+public class AGETResponse {
+
+    @JsonProperty("message")
+    private String message;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public AGETResponse() {
+    }
+
+    /**
+     * 
+     * @param message
+     */
+    public AGETResponse(String message) {
+        super();
+        this.message = message;
+    }
+
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public AGETResponse withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public AGETResponse withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("message", message).append("additionalProperties", additionalProperties).toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(message).append(additionalProperties).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof AGETResponse) == false) {
+            return false;
+        }
+        AGETResponse rhs = ((AGETResponse) other);
+        return new EqualsBuilder().append(message, rhs.message).append(additionalProperties, rhs.additionalProperties).isEquals();
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/b/B.java
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/b/B.java
@@ -1,0 +1,45 @@
+
+package same_path_multiple_times.resource.foo.b;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import same_path_multiple_times.exceptions.FooException;
+
+public class B {
+
+    private String _baseUrl;
+    private Client _client;
+
+    public B() {
+        _baseUrl = null;
+        _client = null;
+    }
+
+    public B(String baseUrl, Client _client) {
+        _baseUrl = (baseUrl +"/b");
+        this._client = _client;
+    }
+
+    protected Client getClient() {
+        return this._client;
+    }
+
+    private String getBaseUri() {
+        return _baseUrl;
+    }
+
+    public same_path_multiple_times.resource.foo.b.model.BGETResponse get() {
+        WebTarget target = this._client.target(getBaseUri());
+        final javax.ws.rs.client.Invocation.Builder invocationBuilder = target.request(MediaType.APPLICATION_JSON_TYPE);
+        Response response = invocationBuilder.get();
+        if (response.getStatusInfo().getFamily()!= Family.SUCCESSFUL) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new FooException(statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
+        }
+        return response.readEntity(same_path_multiple_times.resource.foo.b.model.BGETResponse.class);
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/b/model/BGETResponse.java
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/b/model/BGETResponse.java
@@ -1,0 +1,95 @@
+
+package same_path_multiple_times.resource.foo.b.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "message"
+})
+public class BGETResponse {
+
+    @JsonProperty("message")
+    private String message;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public BGETResponse() {
+    }
+
+    /**
+     * 
+     * @param message
+     */
+    public BGETResponse(String message) {
+        super();
+        this.message = message;
+    }
+
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public BGETResponse withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public BGETResponse withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("message", message).append("additionalProperties", additionalProperties).toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(message).append(additionalProperties).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof BGETResponse) == false) {
+            return false;
+        }
+        BGETResponse rhs = ((BGETResponse) other);
+        return new EqualsBuilder().append(message, rhs.message).append(additionalProperties, rhs.additionalProperties).isEquals();
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/model/FooGETResponse.java
+++ b/raml-client-generator-core/src/test/resources/v1/same_path_multiple_times/output/same_path_multiple_times/resource/foo/model/FooGETResponse.java
@@ -1,0 +1,95 @@
+
+package same_path_multiple_times.resource.foo.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "message"
+})
+public class FooGETResponse {
+
+    @JsonProperty("message")
+    private String message;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public FooGETResponse() {
+    }
+
+    /**
+     * 
+     * @param message
+     */
+    public FooGETResponse(String message) {
+        super();
+        this.message = message;
+    }
+
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public FooGETResponse withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public FooGETResponse withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("message", message).append("additionalProperties", additionalProperties).toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(message).append(additionalProperties).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof FooGETResponse) == false) {
+            return false;
+        }
+        FooGETResponse rhs = ((FooGETResponse) other);
+        return new EqualsBuilder().append(message, rhs.message).append(additionalProperties, rhs.additionalProperties).isEquals();
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/api.raml
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/api.raml
@@ -1,0 +1,32 @@
+#%RAML 1.0
+title: Foo
+version: 0.1
+mediaType: application/json
+documentation:
+  - title : Foo
+    content : A String
+/foo:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              { "message": "foo" }
+/foo/a:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              { "message": "foo" }
+/foo/b:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              { "message": "foo" }
+

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/api/FooClient.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/api/FooClient.java
@@ -1,0 +1,40 @@
+
+package same_path_multiple_times.api;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import same_path_multiple_times.resource.foo.Foo;
+
+
+/**
+ * A String
+ * 
+ */
+public class FooClient {
+
+    private String _baseUrl;
+    public final Foo foo;
+
+    public FooClient() {
+        _baseUrl = null;
+        foo = null;
+    }
+
+    public FooClient(String baseUrl) {
+        _baseUrl = baseUrl;
+        foo = new Foo(getBaseUri(), getClient());
+    }
+
+    protected Client getClient() {
+        return ClientBuilder.newClient();
+    }
+
+    protected String getBaseUri() {
+        return _baseUrl;
+    }
+
+    public static FooClient create(String baseUrl) {
+        return new FooClient(baseUrl);
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/exceptions/FooException.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/exceptions/FooException.java
@@ -1,0 +1,25 @@
+
+package same_path_multiple_times.exceptions;
+
+
+public class FooException
+    extends RuntimeException
+{
+
+    private int statusCode;
+    private String reason;
+
+    public FooException(int statusCode, String reason) {
+        this.statusCode = statusCode;
+        this.reason = reason;
+    }
+
+    public int getStatusCode() {
+        return this.statusCode;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/Foo.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/Foo.java
@@ -1,0 +1,55 @@
+
+package same_path_multiple_times.resource.foo;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import same_path_multiple_times.exceptions.FooException;
+import same_path_multiple_times.resource.foo.a.A;
+import same_path_multiple_times.resource.foo.b.B;
+import same_path_multiple_times.responses.FooResponse;
+
+public class Foo {
+
+    private String _baseUrl;
+    private Client _client;
+    public final A a;
+    public final B b;
+
+    public Foo() {
+        _baseUrl = null;
+        _client = null;
+        a = null;
+        b = null;
+    }
+
+    public Foo(String baseUrl, Client _client) {
+        _baseUrl = (baseUrl +"/foo");
+        this._client = _client;
+        a = new A(getBaseUri(), getClient());
+        b = new B(getBaseUri(), getClient());
+    }
+
+    protected Client getClient() {
+        return this._client;
+    }
+
+    private String getBaseUri() {
+        return _baseUrl;
+    }
+
+    public FooResponse<same_path_multiple_times.resource.foo.model.FooGETResponseBody> get() {
+        WebTarget target = this._client.target(getBaseUri());
+        final javax.ws.rs.client.Invocation.Builder invocationBuilder = target.request(MediaType.APPLICATION_JSON_TYPE);
+        Response response = invocationBuilder.get();
+        if (response.getStatusInfo().getFamily()!= Family.SUCCESSFUL) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new FooException(statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
+        }
+        FooResponse<same_path_multiple_times.resource.foo.model.FooGETResponseBody> apiResponse = new FooResponse<same_path_multiple_times.resource.foo.model.FooGETResponseBody>(response.readEntity(same_path_multiple_times.resource.foo.model.FooGETResponseBody.class), response.getStringHeaders(), response);
+        return apiResponse;
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/a/A.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/a/A.java
@@ -1,0 +1,47 @@
+
+package same_path_multiple_times.resource.foo.a;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import same_path_multiple_times.exceptions.FooException;
+import same_path_multiple_times.responses.FooResponse;
+
+public class A {
+
+    private String _baseUrl;
+    private Client _client;
+
+    public A() {
+        _baseUrl = null;
+        _client = null;
+    }
+
+    public A(String baseUrl, Client _client) {
+        _baseUrl = (baseUrl +"/a");
+        this._client = _client;
+    }
+
+    protected Client getClient() {
+        return this._client;
+    }
+
+    private String getBaseUri() {
+        return _baseUrl;
+    }
+
+    public FooResponse<same_path_multiple_times.resource.foo.a.model.AGETResponseBody> get() {
+        WebTarget target = this._client.target(getBaseUri());
+        final javax.ws.rs.client.Invocation.Builder invocationBuilder = target.request(MediaType.APPLICATION_JSON_TYPE);
+        Response response = invocationBuilder.get();
+        if (response.getStatusInfo().getFamily()!= Family.SUCCESSFUL) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new FooException(statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
+        }
+        FooResponse<same_path_multiple_times.resource.foo.a.model.AGETResponseBody> apiResponse = new FooResponse<same_path_multiple_times.resource.foo.a.model.AGETResponseBody>(response.readEntity(same_path_multiple_times.resource.foo.a.model.AGETResponseBody.class), response.getStringHeaders(), response);
+        return apiResponse;
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/a/model/AGETResponseBody.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/a/model/AGETResponseBody.java
@@ -1,0 +1,95 @@
+
+package same_path_multiple_times.resource.foo.a.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "message"
+})
+public class AGETResponseBody {
+
+    @JsonProperty("message")
+    private String message;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public AGETResponseBody() {
+    }
+
+    /**
+     * 
+     * @param message
+     */
+    public AGETResponseBody(String message) {
+        super();
+        this.message = message;
+    }
+
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public AGETResponseBody withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public AGETResponseBody withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("message", message).append("additionalProperties", additionalProperties).toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(message).append(additionalProperties).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof AGETResponseBody) == false) {
+            return false;
+        }
+        AGETResponseBody rhs = ((AGETResponseBody) other);
+        return new EqualsBuilder().append(message, rhs.message).append(additionalProperties, rhs.additionalProperties).isEquals();
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/b/B.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/b/B.java
@@ -1,0 +1,47 @@
+
+package same_path_multiple_times.resource.foo.b;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import same_path_multiple_times.exceptions.FooException;
+import same_path_multiple_times.responses.FooResponse;
+
+public class B {
+
+    private String _baseUrl;
+    private Client _client;
+
+    public B() {
+        _baseUrl = null;
+        _client = null;
+    }
+
+    public B(String baseUrl, Client _client) {
+        _baseUrl = (baseUrl +"/b");
+        this._client = _client;
+    }
+
+    protected Client getClient() {
+        return this._client;
+    }
+
+    private String getBaseUri() {
+        return _baseUrl;
+    }
+
+    public FooResponse<same_path_multiple_times.resource.foo.b.model.BGETResponseBody> get() {
+        WebTarget target = this._client.target(getBaseUri());
+        final javax.ws.rs.client.Invocation.Builder invocationBuilder = target.request(MediaType.APPLICATION_JSON_TYPE);
+        Response response = invocationBuilder.get();
+        if (response.getStatusInfo().getFamily()!= Family.SUCCESSFUL) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new FooException(statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
+        }
+        FooResponse<same_path_multiple_times.resource.foo.b.model.BGETResponseBody> apiResponse = new FooResponse<same_path_multiple_times.resource.foo.b.model.BGETResponseBody>(response.readEntity(same_path_multiple_times.resource.foo.b.model.BGETResponseBody.class), response.getStringHeaders(), response);
+        return apiResponse;
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/b/model/BGETResponseBody.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/b/model/BGETResponseBody.java
@@ -1,0 +1,95 @@
+
+package same_path_multiple_times.resource.foo.b.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "message"
+})
+public class BGETResponseBody {
+
+    @JsonProperty("message")
+    private String message;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public BGETResponseBody() {
+    }
+
+    /**
+     * 
+     * @param message
+     */
+    public BGETResponseBody(String message) {
+        super();
+        this.message = message;
+    }
+
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public BGETResponseBody withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public BGETResponseBody withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("message", message).append("additionalProperties", additionalProperties).toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(message).append(additionalProperties).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof BGETResponseBody) == false) {
+            return false;
+        }
+        BGETResponseBody rhs = ((BGETResponseBody) other);
+        return new EqualsBuilder().append(message, rhs.message).append(additionalProperties, rhs.additionalProperties).isEquals();
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/model/FooGETResponseBody.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/resource/foo/model/FooGETResponseBody.java
@@ -1,0 +1,95 @@
+
+package same_path_multiple_times.resource.foo.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "message"
+})
+public class FooGETResponseBody {
+
+    @JsonProperty("message")
+    private String message;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public FooGETResponseBody() {
+    }
+
+    /**
+     * 
+     * @param message
+     */
+    public FooGETResponseBody(String message) {
+        super();
+        this.message = message;
+    }
+
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public FooGETResponseBody withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public FooGETResponseBody withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("message", message).append("additionalProperties", additionalProperties).toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(message).append(additionalProperties).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof FooGETResponseBody) == false) {
+            return false;
+        }
+        FooGETResponseBody rhs = ((FooGETResponseBody) other);
+        return new EqualsBuilder().append(message, rhs.message).append(additionalProperties, rhs.additionalProperties).isEquals();
+    }
+
+}

--- a/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/responses/FooResponse.java
+++ b/raml-client-generator-core/src/test/resources/v2/same_path_multiple_times/output/same_path_multiple_times/responses/FooResponse.java
@@ -1,0 +1,31 @@
+
+package same_path_multiple_times.responses;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+public class FooResponse<T >{
+
+    private T body;
+    private MultivaluedMap<String, String> headers;
+    private Response response;
+
+    public FooResponse(T body, MultivaluedMap<String, String> headers, Response response) {
+        this.body = body;
+        this.headers = headers;
+        this.response = response;
+    }
+
+    public T getBody() {
+        return this.body;
+    }
+
+    public MultivaluedMap<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    public Response getResponse() {
+        return this.response;
+    }
+
+}

--- a/raml-client-generator-maven-plugin/pom.xml
+++ b/raml-client-generator-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.mule.raml.codegen</groupId>
             <artifactId>raml-client-generator-core</artifactId>
-            <version>0.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- dependencies to annotations -->


### PR DESCRIPTION
When multiple subresources are defined with full path the fields for the sub-resource is not assigned in the default constructor. 