### PR TITLE
Add option for using BigDecimal for number type

### DIFF
--- a/raml-client-generator-core/src/main/java/org/mule/client/codegen/CodeGenConfig.java
+++ b/raml-client-generator-core/src/main/java/org/mule/client/codegen/CodeGenConfig.java
@@ -8,6 +8,8 @@ public class CodeGenConfig {
 
     private boolean useJava8Optional = false;
 
+    private boolean useBigDecimals = false;
+
     private String targetVersion = "1.6";
 
     public CodeGenConfig() {
@@ -38,6 +40,15 @@ public class CodeGenConfig {
 
     public CodeGenConfig setUseJava8Dates(boolean useJava8Dates) {
         this.useJava8Dates = useJava8Dates;
+        return this;
+    }
+
+    public boolean getUseBigDecimals() {
+        return useBigDecimals;
+    }
+
+    public CodeGenConfig setUseBigDecimals(boolean useBigDecimals) {
+        this.useBigDecimals = useBigDecimals;
         return this;
     }
 

--- a/raml-client-generator-core/src/main/java/org/mule/client/codegen/RamlJavaClientGenerator.java
+++ b/raml-client-generator-core/src/main/java/org/mule/client/codegen/RamlJavaClientGenerator.java
@@ -669,6 +669,11 @@ public class RamlJavaClientGenerator {
         }
 
         @Override
+        public boolean isUseBigDecimals() {
+            return codeGenConfig.getUseBigDecimals();
+        }
+
+        @Override
         public String getTargetVersion() {
             return codeGenConfig.getTargetVersion();
         }

--- a/raml-client-generator-core/src/test/java/org/mule/client/codegen/RamlJavaClientGeneratorTest.java
+++ b/raml-client-generator-core/src/test/java/org/mule/client/codegen/RamlJavaClientGeneratorTest.java
@@ -90,6 +90,7 @@ public class RamlJavaClientGeneratorTest {
             codeGenConfig.setUseJava8Dates(Boolean.parseBoolean(properties.getProperty("java8Dates", "false")));
             codeGenConfig.setUseJava8Optional(Boolean.parseBoolean(properties.getProperty("optionals", "false")));
             codeGenConfig.setIncludeAdditionalProperties(Boolean.parseBoolean(properties.getProperty("additionalProperties", "false")));
+            codeGenConfig.setUseBigDecimals(Boolean.parseBoolean(properties.getProperty("useBigDecimals", "false")));
         }
         new RamlJavaClientGenerator(projectName, actualTarget, outputVersion, codeGenConfig).generate(resource);
         assert resource != null;

--- a/raml-client-generator-maven-plugin/src/main/java/org/mule/client/codegen/maven/plugin/RamlJavaClientGeneratorMojo.java
+++ b/raml-client-generator-maven-plugin/src/main/java/org/mule/client/codegen/maven/plugin/RamlJavaClientGeneratorMojo.java
@@ -41,6 +41,9 @@ public class RamlJavaClientGeneratorMojo extends AbstractMojo {
     private Boolean includeAdditionalProperties;
 
     @Parameter(defaultValue = "false")
+    private Boolean useBigDecimals;
+
+    @Parameter(defaultValue = "false")
     private Boolean useOptionalForGetters;
 
     @Parameter(defaultValue = "v2", property = "RamlJavaClientGeneratorMojo.outputVersion")
@@ -75,7 +78,8 @@ public class RamlJavaClientGeneratorMojo extends AbstractMojo {
                 codeGenConfig
                         .setUseJava8Dates(useJava8Dates)
                         .setIncludeAdditionalProperties(includeAdditionalProperties)
-                        .setUseJava8Optional(useOptionalForGetters);
+                        .setUseJava8Optional(useOptionalForGetters)
+                        .setUseBigDecimals(useBigDecimals);
 
                 final RamlJavaClientGenerator ramlJavaClientGenerator = new RamlJavaClientGenerator(basePackage, new File(outputDir), outputVersion, codeGenConfig);
                 ramlJavaClientGenerator.generate(ramlUrl);

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,8 @@ There is also a maven plugin that allows you to generate the client code during 
                             <includeAdditionalProperties>false</includeAdditionalProperties>
                             <!--False by default                            -->
                             <useOptionalForGetters>false</useOptionalForGetters>
+                            <!--False by default                            -->
+                            <useBigDecimals>false</useBigDecimals>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
We are using generated clients to transfer monetary data for fields that
are declared as type:number. Before this commit Double would be
generated for number types which was not adequate for transfering
monetary data.  This commit exposes the option provided by
jsonschema2pojo to generate BigDecimals for numbers.

NOTE: raml-spec does not define arbitrary precision numbers but only
provides the option to select from fixed precision formats. Despite this
we think that using BigDecimals on clients is reasonable to represent &
transfer such information. Their use is supported by various tools such
as serializers/deserializers eg jackson and code generators for other
specifications eg openapi-generator-maven-plugin.